### PR TITLE
Ew 150 duplicate documents and corrupted file bug

### DIFF
--- a/epfirms-api/src/middleware/CommonMiddleware.ts
+++ b/epfirms-api/src/middleware/CommonMiddleware.ts
@@ -41,12 +41,13 @@ export class CommonMiddleware {
   }
 
   public async useBodyParser() {
-    this.app.use(bodyParser.json());
+    this.app.use(bodyParser.json({limit: '5mb'}));
   }
 
   public async useURLencoded() {
     this.app.use(
       bodyParser.urlencoded({
+        limit: '5mb',
         extended: true
       })
     );

--- a/epfirms-api/src/modules/payment-processor/controllers/webhook.controller.ts
+++ b/epfirms-api/src/modules/payment-processor/controllers/webhook.controller.ts
@@ -8,11 +8,11 @@ export class PaymentProcessorWebhookController {
   public async handleInvoiceWebhook(req: Request, resp: Response): Promise<any> {
     try {
       const event = req.body;
-      const { customer, period_end, customer_email } = event.data.object;
-
+      const { customer, customer_email, lines } = event.data.object;
+      const current_period_end = lines.data[0].period.end;
       switch (event.type) {
         case 'invoice.paid':
-          await PaymentProcessorService.handlePaidInvoice(customer, period_end);
+          await PaymentProcessorService.handlePaidInvoice(customer, current_period_end);
           break;
         case 'invoice.upcoming':
           await PaymentProcessorService.handleUpcomingInvoice(customer_email);

--- a/epfirms-client/package-lock.json
+++ b/epfirms-client/package-lock.json
@@ -36,6 +36,7 @@
         "ngx-quill": "^16.1.1",
         "ngx-socket-io": "^4.1.0",
         "ngx-stripe": "^13.0.0",
+        "quill-image-compress": "^1.2.21",
         "rxjs": "^7.4.0",
         "tslib": "^2.3.1",
         "zone.js": "~0.11.4"
@@ -12401,6 +12402,14 @@
         "quill-delta": "^3.6.2"
       }
     },
+    "node_modules/quill-image-compress": {
+      "version": "1.2.21",
+      "resolved": "https://registry.npmjs.org/quill-image-compress/-/quill-image-compress-1.2.21.tgz",
+      "integrity": "sha512-B6vUb/0HSy6bX+h2CCkuLqmJLtmwdF3ZMlzN9o4Y7gzD/knxEV513pWqOgqnk1aMT+yV2g4OVGKSlBWe8g+ReA==",
+      "dependencies": {
+        "quill": "^1.x"
+      }
+    },
     "node_modules/quill/node_modules/eventemitter3": {
       "version": "2.0.3",
       "license": "MIT"
@@ -23028,6 +23037,14 @@
             "fast-diff": "1.1.2"
           }
         }
+      }
+    },
+    "quill-image-compress": {
+      "version": "1.2.21",
+      "resolved": "https://registry.npmjs.org/quill-image-compress/-/quill-image-compress-1.2.21.tgz",
+      "integrity": "sha512-B6vUb/0HSy6bX+h2CCkuLqmJLtmwdF3ZMlzN9o4Y7gzD/knxEV513pWqOgqnk1aMT+yV2g4OVGKSlBWe8g+ReA==",
+      "requires": {
+        "quill": "^1.x"
       }
     },
     "randombytes": {

--- a/epfirms-client/package.json
+++ b/epfirms-client/package.json
@@ -39,6 +39,7 @@
     "ngx-quill": "^16.1.1",
     "ngx-socket-io": "^4.1.0",
     "ngx-stripe": "^13.0.0",
+    "quill-image-compress": "^1.2.21",
     "rxjs": "^7.4.0",
     "tslib": "^2.3.1",
     "zone.js": "~0.11.4"

--- a/epfirms-client/src/app/app.module.ts
+++ b/epfirms-client/src/app/app.module.ts
@@ -24,6 +24,7 @@ import { ConfirmDialogComponent } from './shared/confirm-dialog/confirm-dialog.c
 import { QuillModule } from 'ngx-quill';
 import { AutocompleteModule } from './shared/autocomplete/autocomplete.module';
 import { HotToastModule } from '@ngneat/hot-toast';
+import ImageCompress from 'quill-image-compress';
 
 const defaultDataServiceConfig: DefaultDataServiceConfig = {
   root: '/api',
@@ -59,7 +60,7 @@ const quillConfig = [
 
 @NgModule({
   declarations: [
-    AppComponent,
+    AppComponent
   ],
   imports: [
     BrowserModule,
@@ -75,8 +76,17 @@ const quillConfig = [
     EntityDataModule.forRoot(entityConfig),
     QuillModule.forRoot({
       modules: {
-        toolbar: quillConfig
+        toolbar: quillConfig,
+        imageCompress: {
+          quality: 0.7
+        }
       },
+      customModules: [
+        {
+          implementation: ImageCompress,
+          path: 'modules/imageCompress'
+        }
+      ],
       format: 'json'
     }),
     extModules,

--- a/epfirms-client/src/app/features/matter-tab/matter-tab-notes/matter-tab-notes.component.html
+++ b/epfirms-client/src/app/features/matter-tab/matter-tab-notes/matter-tab-notes.component.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-6">
+<div class="w-1/2 px-4 py-6 sm:px-6">
     <div>
       <ul role="list" class="divide-y divide-slate-200">
         <li class="py-4" *ngFor="let note of matterNotes">
@@ -8,9 +8,9 @@
             <div class="flex-1 space-y-1">
               <div class="flex items-center justify-between">
                 <h3 class="text-sm font-medium">{{note.user.first_name + ' ' + note.user.last_name | titlecase}}</h3>
-                <div class="inline-flex items-center"><p class="text-sm text-slate-500 mr-2">{{note.created_at | date:'MMM d, y \'at\' h:mm a'}}</p> 
-                  <button (click)="deleteNote(note.id)" type="button" class="-m-2 p-2 rounded-full flex items-center text-slate-300 hover:text-slate-600">
-                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                <div class="inline-flex items-center"><p class="mr-2 text-sm text-slate-500">{{note.created_at | date:'MMM d, y \'at\' h:mm a'}}</p> 
+                  <button (click)="deleteNote(note.id)" type="button" class="flex items-center p-2 -m-2 rounded-full text-slate-300 hover:text-slate-600">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
                       <path fill-rule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd" />
                     </svg>
                   </button></div>
@@ -26,38 +26,36 @@
     </div>
   </div>
   
-  <div class="bg-slate-50 px-4 py-6 sm:px-6 sticky bottom-0">
-    <div class="flex space-x-3">
-      <div class="flex-shrink-0">
+  <div class="absolute top-0 bottom-0 left-0 w-1/3 px-4 py-6 border-r border-gray-200 bg-slate-50 sm:px-6">
+    <div class="flex h-full space-x-3">
+      <div class="flex-shrink-0 overflow-y-auto">
         <ng-container *ngIf="currentUser$ | async as currentUser">
           <ep-avatar epSize="medium" [epSrc]="currentUser.profile_image" [epText]="currentUser.full_name"></ep-avatar>
         </ng-container>
       </div>
-      <div class="min-w-0 flex-1">
-        <div>
+      <div class="flex flex-col flex-1 min-w-0">
+        <div class="flex-1">
           <label for="note" class="sr-only">Note</label>
-          <quill-editor [(ngModel)]="note" [styles]="{height: '150px', 'background-color': '#fff'}"></quill-editor>
+          <quill-editor [(ngModel)]="note" [styles]="{height: '100%', 'background-color': '#fff', 'border-bottom-left-radius': '.5rem', 'border-bottom-right-radius': '.5rem', 'border': '1px solid rgb(203, 213, 225)', 'border-top': 0}">
+            <div quill-editor-toolbar style="background: white; border-top-left-radius: .5rem;border-top-right-radius: .5rem; border: 1px solid rgb(203, 213, 225); border-bottom: 0">
+              <span class="ql-formats">
+                <button class="ql-bold"></button>
+                <button class="ql-italic"></button>
+                <button class="ql-underline"></button>
+                <button class="ql-strike"></button>
+              </span>
+              <span class="ql-formats">
+                <button class="ql-list" value="ordered"></button>
+                <button class="ql-list" value="bullet"></button>
+              </span>
+              <span class="ql-formats">
+                <button class="ql-image"></button>
+              </span>
+            </div>
+          </quill-editor>
         </div>
-        <div class="mt-3 flex items-center justify-between">
-          <button (click)="addNote()" class="
-                inline-flex
-                items-center
-                justify-center
-                px-4
-                py-2
-                border border-transparent
-                text-sm
-                font-medium
-                rounded-md
-                shadow-sm
-                text-white
-                bg-blue-600
-                hover:bg-blue-700
-                focus:outline-none
-                focus:ring-2
-                focus:ring-offset-2
-                focus:ring-blue-500
-              ">
+        <div class="z-10 flex items-center justify-end">
+          <button (click)="addNote()" class="inline-flex items-center justify-center px-4 py-2 mb-2 mr-1.5 text-sm font-medium text-white bg-blue-600 border border-transparent rounded-md shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
             Add note
           </button>
         </div>

--- a/epfirms-client/src/app/features/matter-tab/matter-tab-notes/matter-tab-notes.component.ts
+++ b/epfirms-client/src/app/features/matter-tab/matter-tab-notes/matter-tab-notes.component.ts
@@ -10,7 +10,10 @@ import { MatterService } from '@app/firm-portal/_services/matter-service/matter.
 @Component({
   selector: 'app-matter-tab-notes',
   templateUrl: './matter-tab-notes.component.html',
-  styleUrls: ['./matter-tab-notes.component.scss']
+  styleUrls: ['./matter-tab-notes.component.scss'],
+  host: {
+    'class': 'flex flex-row-reverse h-full'
+  }
 })
 export class MatterTabNotesComponent {
   @Input()

--- a/epfirms-client/src/app/features/matter-tab/matter-tabs/matter-tabs.component.ts
+++ b/epfirms-client/src/app/features/matter-tab/matter-tabs/matter-tabs.component.ts
@@ -18,7 +18,7 @@ import { HotToastService } from '@ngneat/hot-toast';
   templateUrl: './matter-tabs.component.html',
   styleUrls: ['./matter-tabs.component.scss'],
   host: {
-    'class': 'fixed inset-0 left-64 transition-expand ease-in-out duration-500',
+    'class': 'fixed inset-0 left-20 transition-expand ease-in-out duration-500 lg:left-64',
     '[class.translate-y-tabs]': '!expanded',
     '[class.translate-y-0]': 'expanded'
   }

--- a/epfirms-client/src/app/shared/input/directives/input.directive.ts
+++ b/epfirms-client/src/app/shared/input/directives/input.directive.ts
@@ -2,6 +2,7 @@ import { coerceBooleanProperty } from '@angular/cdk/coercion';
 import {
   Directive,
   ElementRef,
+  HostListener,
   Input,
   OnChanges,
   OnDestroy,
@@ -25,6 +26,14 @@ import { filter, takeUntil } from 'rxjs/operators';
   }
 })
 export class InputDirective implements OnChanges, OnInit, OnDestroy {
+  @HostListener('blur') trimOnBlur() {
+    const trimmedValue = this.elementRef.nativeElement.value.trim();
+    this.elementRef.nativeElement.value = trimmedValue;
+    if (this.ngControl) {
+      this.ngControl.control.setValue(trimmedValue);
+    }
+  }
+  
   @Input()
   get disabled(): boolean {
     if (this.ngControl && this.ngControl.disabled !== null) {
@@ -33,6 +42,7 @@ export class InputDirective implements OnChanges, OnInit, OnDestroy {
 
     return this._disabled;
   }
+
   set disabled(value: boolean) {
     this._disabled = coerceBooleanProperty(value);
   }
@@ -41,14 +51,17 @@ export class InputDirective implements OnChanges, OnInit, OnDestroy {
   get editable(): boolean {
     return this._editable;
   }
+
   set editable(value: boolean) {
     this._editable = coerceBooleanProperty(value);
   }
 
   private _disabled = false;
+
   private _editable = false;
 
   disabled$ = new Subject<boolean>();
+
   editable$ = new Subject<boolean>();
 
   private destroy$ = new Subject<void>();


### PR DESCRIPTION
**Notes feature:**
- Design change per Taylor's request
- Fixed error being thrown when adding a larger image to a note. This was caused by a size limit in the body-parser middleware. Images are also now being compressed in notes.

**Other Bug fixes:**
- All inputs using the ep-input directive now trim white space by default. This was causing an issue when creating a new client where names would be surrounded by spaces. Searching for a client's name in the client directory required an extra space before they showed up.
- Stripe's 'invoice paid' webhook used the wrong date property when updating the firm's subscription.